### PR TITLE
Add autoload cookie for python-test project-root and backend

### DIFF
--- a/python-test.el
+++ b/python-test.el
@@ -87,6 +87,7 @@
   :type 'string
   :safe #'stringp
   :group 'python-test)
+;;;###autoload(put 'python-test-project-root 'safe-local-variable #'stringp)
 
 (defcustom python-test-project-root-files
   '("setup.py"                          ; Setuptools file
@@ -116,6 +117,7 @@ The topmost match has precedence."
                 (mapcar (lambda (x) (list 'const x)) python-test-backends))
   :safe #'python-test-registered-backend-p
   :group 'python-test)
+;;;###autoload(put 'python-test-backend 'safe-local-variable #'python-test-registered-backend-p)
 
 (defvar python-test-command-history nil)
 
@@ -164,6 +166,7 @@ The topmost match has precedence."
 
 
 ;;; Internal functions
+;;;###autoload
 (defun python-test-registered-backend-p (backend)
   "Determine whether `org-sync' BACKEND is registered."
   (memq backend python-test-backends))


### PR DESCRIPTION
The defcustom `safe` property is only evaluated after the package
is loaded, this means that if someone sets those variables
in his dir-locals and goes to the project without having python-test
loaded before, he gets a warning.

From the elisp "File Local Variables" manual:
-----
   When defining a user option using ‘defcustom’, you can set its
‘safe-local-variable’ property by adding the arguments ‘:safe FUNCTION’
to ‘defcustom’ (*note Variable Definitions::).  However, a safety
predicate defined using ‘:safe’ will only be known once the package that
contains the ‘defcustom’ is loaded, which is often too late.  As an
alternative, you can use the autoload cookie (*note Autoload::) to
assign the option its safety predicate, like this:

     ;;;###autoload (put 'VAR 'safe-local-variable 'PRED)

The safe value definitions specified with ‘autoload’ are copied into the
package’s autoloads file (‘loaddefs.el’ for most packages bundled with
Emacs), and are known to Emacs since the beginning of a session.
